### PR TITLE
fix for changed /proc/cpuinfo hardware string

### DIFF
--- a/lib/usonic.js
+++ b/lib/usonic.js
@@ -26,9 +26,9 @@ var init = function (callback) {
 
         var hardware = stdout.split(':')[1].trim();
 
-        if (hardware === 'BCM2708' || hardware === 'BCM2835') {
+        if (hardware === 'BCM2708') {
             usonic.init(1);
-        } else if (hardware === 'BCM2709') {
+        } else if (hardware === 'BCM2709' || hardware === 'BCM2835') {
             usonic.init(2);
         } else {
             return callback(new Error('unknown hardware: "' + hardware + '"'));

--- a/lib/usonic.js
+++ b/lib/usonic.js
@@ -26,7 +26,7 @@ var init = function (callback) {
 
         var hardware = stdout.split(':')[1].trim();
 
-        if (hardware === 'BCM2708') {
+        if (hardware === 'BCM2708' || hardware === 'BCM2835') {
             usonic.init(1);
         } else if (hardware === 'BCM2709') {
             usonic.init(2);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "mmap"
     ],
     "author": {
-        "name": "Clemens Akens w/ Luke Moch, Matthew Berryman",
+        "name": "Clemens Akens w/ Luke Moch",
         "email": "lukemochspam@gmail.com",
         "url": "http://github.com/mochman"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mmm-usonic",
-    "version": "2.5.3",
+    "version": "2.5.4",
     "description": "A high performance, memory mapped, Node.js API for the HC-SR04 ultrasonic sensor connected to a Raspberry Pi.",
     "keywords": [
         "raspberry",
@@ -12,7 +12,7 @@
         "mmap"
     ],
     "author": {
-        "name": "Clemens Akens w/ Luke Moch",
+        "name": "Clemens Akens w/ Luke Moch, Matthew Berryman",
         "email": "lukemochspam@gmail.com",
         "url": "http://github.com/mochman"
     },


### PR DESCRIPTION
There's a change in the Hardware string as reported by /proc/cpuinfo that has just made its way into the kernel, see https://github.com/raspberrypi/firmware/issues/705 and https://raspberrypi.stackexchange.com/questions/840/why-is-the-cpu-sometimes-referred-to-as-bcm2708-sometimes-bcm2835 for more info.

This fix means that the mmm-usonic works against the new string.